### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,5 +23,5 @@
     "64": "images/Rainbow.surf-icon-64.png"
   },
   "content_security_policy": "default-src 'self'",
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
The Chrome Web Store no longer accepts Manifest V2 extensions. Follow the Manifest V3 Migration guide to convert your extension to Manifest V3.